### PR TITLE
Add Neo4j vector search using 2026.01 syntax and in-index filtering

### DIFF
--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -1,14 +1,12 @@
 import { googleAI } from '@genkit-ai/googleai';
 import { Document, genkit } from 'genkit';
 import { test, describe, expect, afterAll, beforeAll, beforeEach, afterEach } from '@jest/globals';
-import { Driver, auth, driver as neo4jDriver, Session } from 'neo4j-driver';
 import { neo4j, neo4jIndexerRef, neo4jRetrieverRef } from '..';
 
-// Import the Testcontainers equivalent for Node.js
-import { Neo4jContainer, StartedNeo4jContainer } from '@testcontainers/neo4j';
 import { mockEmbedder } from '../dummyEmbedder';
-import { Wait } from 'testcontainers';
 import { fail } from 'assert';
+import { setupNeo4jTestEnvironment } from '../test-utils';
+
 
 /**
  * This file contains integration tests for the Genkit Neo4j plugin,
@@ -16,94 +14,17 @@ import { fail } from 'assert';
  * for each test run.
  */
 describe('Neo4j Plugin Integration', () => {
-  
-  // Reference to the Testcontainers Neo4j instance
-  let neo4jContainer: StartedNeo4jContainer;
-
-  // Global variables for the Genkit instance and Neo4j connection
-  let ai: ReturnType<typeof genkit>;
-  let driver: Driver;
-  let session: Session;
 
   // Unique ID used for the vector index in Neo4j (corresponds to the node label)
   const indexId = 'genkit-test-index';
   // Cypher Label for the node, quoted for safety
-  const INDEX_LABEL = `\`${indexId}\``; 
+  const INDEX_LABEL = `\`${indexId}\``;
   const INDEXER_REF = neo4jIndexerRef({ indexId });
   const RETRIEVER_REF = neo4jRetrieverRef({ indexId });
-  const CLEANUP_QUERY = `MATCH (n) DETACH DELETE n`;
   const FIND_NODE_QUERY = `MATCH (n:${INDEX_LABEL} {uniqueId: $uniqueId}) RETURN n`;
 
-  let clientParams;
-  
-  // --- Setup and Teardown ---
-
-  beforeAll(async () => {
-
-    // 1. Start the Neo4j Docker container using Testcontainers.
-    // This automatically pulls the image and waits for the database to be ready.
-    neo4jContainer = await new Neo4jContainer('neo4j:5.26.16')
-      .withWaitStrategy(Wait.forLogMessage('Started.'))
-      .start();
-    
-    // 2. Get the dynamically generated connection parameters
-    const uri = neo4jContainer.getBoltUri();
-    const username = neo4jContainer.getUsername();
-    const password = neo4jContainer.getPassword();
-
-    // 3. Initialize the standalone Neo4j driver (for cleanup/verification)
-    driver = neo4jDriver(
-      uri,
-      auth.basic(username, password),
-    );
-  }, 120000);
-
-  beforeEach(async () => {
-
-    // 4. Configure the client with dynamic connection parameters from the container
-    clientParams = {
-        url: neo4jContainer.getBoltUri(),
-        username: neo4jContainer.getUsername(),
-        password: neo4jContainer.getPassword(),
-        database: 'neo4j',
-    };
-
-    // Initialize Genkit with dynamic parameters
-    ai = genkit({
-      plugins: [
-        googleAI(),
-        neo4j([
-          {
-            indexId, 
-            embedder: mockEmbedder, 
-            clientParams: clientParams, 
-          },
-        ]),
-      ],
-    });
-    
-    // Open a new Neo4j session for verification operations
-    session = driver.session();
-  });
-  
-  afterEach(async () => {
-    
-    // Cleanup: deletes all test nodes
-    try {
-      await session.run(CLEANUP_QUERY);
-    } finally {
-      // Close the Neo4j session after cleanup
-      await session.close();
-    }
-  });
-
-  afterAll(async () => {
-    // Close the global Neo4j driver
-    await driver.close();
-    
-    // 5. Stop and dispose of the Testcontainers Neo4j container
-    await neo4jContainer.stop();
-  });
+  // Initialize the before / after / beforeAll / afterAll
+  const setupCtx = setupNeo4jTestEnvironment('5.26.16', indexId);
 
 
   // --- Integration Tests ---
@@ -120,14 +41,14 @@ describe('Neo4j Plugin Integration', () => {
 
     // 2. Action: Index the document
     // Uses the predefined indexer reference (INDEXER_REF)
-    await ai.index({ indexer: INDEXER_REF, documents: [newDocument] });
+    await setupCtx.ai.index({ indexer: INDEXER_REF, documents: [newDocument] });
 
     // 3. Neo4j Verification: ensure the node was created
-    const result = await session.run(
+    const result = await setupCtx.session.run(
       FIND_NODE_QUERY,
       { uniqueId },
     );
-    
+
     expect(result.records).toHaveLength(1);
     expect(result.records[0].get('n').properties.uniqueId).toBe(uniqueId);
     // Verifies that the content was stored correctly
@@ -135,7 +56,7 @@ describe('Neo4j Plugin Integration', () => {
 
     // 4. Action: Retrieve the indexed document
     // Uses the predefined retriever reference (RETRIEVER_REF)
-    const docs = await ai.retrieve({
+    const docs = await setupCtx.ai.retrieve({
       retriever: RETRIEVER_REF,
       query: query,
       options: {
@@ -158,14 +79,14 @@ describe('Neo4j Plugin Integration', () => {
       metadata: { uniqueId },
     });
     const query = 'This is a test document to be indexed.';
-    ai = genkit({
+    setupCtx.ai = genkit({
       plugins: [
         googleAI(),
         neo4j([
           {
             indexId,
             embedder: mockEmbedder,
-            clientParams, 
+            clientParams: setupCtx.clientParams,
             retrievalQuery: "RETURN node.text AS text, {mockProp: '1'} AS metadata"
           },
         ]),
@@ -173,10 +94,10 @@ describe('Neo4j Plugin Integration', () => {
     });
 
     // 2. Action: Index the document
-    await ai.index({ indexer: INDEXER_REF, documents: [newDocument] });
+    await setupCtx.ai.index({ indexer: INDEXER_REF, documents: [newDocument] });
 
     // 3. Neo4j Verification: ensure the node was created
-    const result = await session.run(
+    const result = await setupCtx.session.run(
       FIND_NODE_QUERY,
       { uniqueId },
     );
@@ -187,7 +108,7 @@ describe('Neo4j Plugin Integration', () => {
     expect(result.records[0].get('n').properties.text).toBe(initialText);
 
     // 4. Action: Retrieve the indexed document
-    const docs = await ai.retrieve({
+    const docs = await setupCtx.ai.retrieve({
       retriever: RETRIEVER_REF,
       query: query,
       options: {
@@ -207,14 +128,14 @@ describe('Neo4j Plugin Integration', () => {
   test('should document and retrieve it with custom label and hybrid search', async () => {
     const customLabel = 'customLabel'
     const customLabelIdx = 'customLabelIdx'
-    ai = genkit({
+    setupCtx.ai = genkit({
       plugins: [
         googleAI(),
         neo4j([
           {
             indexId: customLabelIdx,
             embedder: mockEmbedder,
-            clientParams,
+            clientParams: setupCtx.clientParams,
             label: customLabel,
             fullTextQuery: 'document',
           },
@@ -232,9 +153,9 @@ describe('Neo4j Plugin Integration', () => {
 
     const indexerRef = neo4jIndexerRef({ indexId: customLabelIdx });
     const retrieverRef = neo4jRetrieverRef({ indexId: customLabelIdx });
-    await ai.index({ indexer: indexerRef, documents: [newDocument] });
+    await setupCtx.ai.index({ indexer: indexerRef, documents: [newDocument] });
 
-    const docs = await ai.retrieve({
+    const docs = await setupCtx.ai.retrieve({
       retriever: retrieverRef,
       query: 'This is a test document to be indexed.',
       options: {
@@ -247,7 +168,7 @@ describe('Neo4j Plugin Integration', () => {
     
     
     const verificationQuery = `MATCH (n:${customLabel}) RETURN n`;
-    const result = await session.run(verificationQuery);
+    const result = await setupCtx.session.run(verificationQuery);
 
     expect(result.records).toHaveLength(1);
     const allCustomLabels = result.records.every(r => r.get('n').labels[0] == customLabel);
@@ -257,14 +178,14 @@ describe('Neo4j Plugin Integration', () => {
   test('should throws error with filter and hybrid search', async () => {
     const customLabel = 'customLabel'
     const customLabelIdx = 'customLabelIdx'
-    ai = genkit({
+    setupCtx.ai = genkit({
       plugins: [
         googleAI(),
         neo4j([
           {
             indexId: customLabelIdx, 
             embedder: mockEmbedder,
-            clientParams, 
+            clientParams: setupCtx.clientParams,
             label: customLabel,
             fullTextQuery: 'document',
             searchType: 'hybrid',
@@ -283,10 +204,10 @@ describe('Neo4j Plugin Integration', () => {
 
     const indexerRef = neo4jIndexerRef({ indexId: customLabelIdx });
     const retrieverRef = neo4jRetrieverRef({ indexId: customLabelIdx });
-    await ai.index({ indexer: indexerRef, documents: [newDocument] });
+    await setupCtx.ai.index({ indexer: indexerRef, documents: [newDocument] });
 
     try {
-      const docs = await ai.retrieve({
+      const docs = await setupCtx.ai.retrieve({
         retriever: retrieverRef,
         query: 'This is a test document to be indexed.',
         options: {
@@ -305,14 +226,14 @@ describe('Neo4j Plugin Integration', () => {
   test('should document and retrieve it with custom label and hybrid search without fullTextQuery', async () => {
     const customLabel = 'customLabel'
     const customLabelIdx = 'customLabelIdx'
-    ai = genkit({
+    setupCtx.ai = genkit({
       plugins: [
         googleAI(),
         neo4j([
           {
-            indexId: customLabelIdx, 
+            indexId: customLabelIdx,
             embedder: mockEmbedder,
-            clientParams, 
+            clientParams: setupCtx.clientParams,
             label: customLabel,
           },
         ]),
@@ -329,9 +250,9 @@ describe('Neo4j Plugin Integration', () => {
 
     const indexerRef = neo4jIndexerRef({ indexId: customLabelIdx });
     const retrieverRef = neo4jRetrieverRef({ indexId: customLabelIdx });
-    await ai.index({ indexer: indexerRef, documents: [newDocument] });
+    await setupCtx.ai.index({ indexer: indexerRef, documents: [newDocument] });
 
-    const docs = await ai.retrieve({
+    const docs = await setupCtx.ai.retrieve({
       retriever: retrieverRef,
       query: 'This is a test document to be indexed.',
       options: {
@@ -343,7 +264,7 @@ describe('Neo4j Plugin Integration', () => {
     expect(docs[0].content[0].text).toContain('indexing and retrieval');    
     
     const verificationQuery = `MATCH (n:${customLabel}) RETURN n`;
-    const result = await session.run(verificationQuery);
+    const result = await setupCtx.session.run(verificationQuery);
     expect(result.records).toHaveLength(1);
     const allCustomLabels = result.records.every(r => r.get('n').labels[0] == customLabel);
     expect(allCustomLabels).toBeTruthy();
@@ -355,14 +276,14 @@ describe('Neo4j Plugin Integration', () => {
     const customTextProperty = 'customTextProperty'
     const customEmbeddingProperty = 'customEmbeddingProperty'
     const customIdProperty = 'customIdProperty'
-    ai = genkit({
+    setupCtx.ai = genkit({
       plugins: [
         googleAI(),
         neo4j([
           {
-            indexId: customEntitiesIdx, 
+            indexId: customEntitiesIdx,
             embedder: mockEmbedder,
-            clientParams: clientParams, 
+            clientParams: setupCtx.clientParams,
             label: customLabel,
             textProperty: customTextProperty,
             embeddingProperty: customEmbeddingProperty,
@@ -384,9 +305,9 @@ describe('Neo4j Plugin Integration', () => {
 
     const indexerRef = neo4jIndexerRef({ indexId: customEntitiesIdx });
     const retrieverRef = neo4jRetrieverRef({ indexId: customEntitiesIdx });
-    await ai.index({ indexer: indexerRef, documents: [newDocument] });
+    await setupCtx.ai.index({ indexer: indexerRef, documents: [newDocument] });
 
-    const docs = await ai.retrieve({
+    const docs = await setupCtx.ai.retrieve({
       retriever: retrieverRef,
       query: 'This is a test document to be indexed.',
       options: {
@@ -399,7 +320,7 @@ describe('Neo4j Plugin Integration', () => {
     
     
     const verificationQuery = `MATCH (n:${customLabel}) RETURN n`;
-    const result = await session.run(verificationQuery);
+    const result = await setupCtx.session.run(verificationQuery);
 
     expect(result.records).toHaveLength(1);
     const allCustomLabels = result.records.every(r => r.get('n').labels[0] == customLabel);
@@ -419,14 +340,14 @@ describe('Neo4j Plugin Integration', () => {
     const customTextProperty = 'customTextProperty1'
     const customEmbeddingProperty = 'customEmbeddingProperty1'
     const customIdProperty = 'customIdProperty1'
-    ai = genkit({
+    setupCtx.ai = genkit({
       plugins: [
         googleAI(),
         neo4j([
           {
-            indexId: customEntitiesIdx, 
+            indexId: customEntitiesIdx,
             embedder: mockEmbedder,
-            clientParams: clientParams, 
+            clientParams: setupCtx.clientParams,
             label: customLabel,
             textProperty: customTextProperty,
             embeddingProperty: customEmbeddingProperty,
@@ -449,9 +370,9 @@ describe('Neo4j Plugin Integration', () => {
 
     const indexerRef = neo4jIndexerRef({ indexId: customEntitiesIdx });
     const retrieverRef = neo4jRetrieverRef({ indexId: customEntitiesIdx });
-    await ai.index({ indexer: indexerRef, documents: [newDocument] });
+    await setupCtx.ai.index({ indexer: indexerRef, documents: [newDocument] });
 
-    const docs = await ai.retrieve({
+    const docs = await setupCtx.ai.retrieve({
       retriever: retrieverRef,
       query: 'This is a test document to be indexed.',
       options: {
@@ -464,7 +385,7 @@ describe('Neo4j Plugin Integration', () => {
     
     
     const verificationQuery = `MATCH (n:${customLabel}) RETURN n`;
-    const result = await session.run(verificationQuery);
+    const result = await setupCtx.session.run(verificationQuery);
 
     expect(result.records).toHaveLength(1);
     const allCustomLabels = result.records.every(r => r.get('n').labels[0] == customLabel);
@@ -499,11 +420,11 @@ describe('Neo4j Plugin Integration', () => {
     ];
 
     // 2. Action: Index multiple documents
-    await ai.index({ indexer: INDEXER_REF, documents: docsToInsert });
+    await setupCtx.ai.index({ indexer: INDEXER_REF, documents: docsToInsert });
 
     // 3. Neo4j Verification: ensure all 3 nodes with commonId were created
     const verificationQuery = `MATCH (n:${INDEX_LABEL} {commonId: $commonId}) RETURN n`;
-    const result = await session.run(verificationQuery, { commonId });
+    const result = await setupCtx.session.run(verificationQuery, { commonId });
 
     expect(result.records).toHaveLength(3);
     const animals = result.records.map(r => r.get('n').properties.animal);
@@ -513,7 +434,7 @@ describe('Neo4j Plugin Integration', () => {
     const query = 'What animal information is available?';
     const filter = { animal: CAT_ANIMAL, commonId };
 
-    const retrievedDocs = await ai.retrieve({
+    const retrievedDocs = await setupCtx.ai.retrieve({
       retriever: RETRIEVER_REF,
       query: query,
       options: {
@@ -538,17 +459,17 @@ describe('Neo4j Plugin Integration', () => {
     const nonMatchingFilter = { nonExistentField: 'nonExistentValue' };
 
     // 2. Action: Index a document
-    await ai.index({ indexer: INDEXER_REF, documents: [newDocument] });
+    await setupCtx.ai.index({ indexer: INDEXER_REF, documents: [newDocument] });
 
     // 3. Neo4j Verification
-    const createdResult = await session.run(
+    const createdResult = await setupCtx.session.run(
       FIND_NODE_QUERY,
       { uniqueId },
     );
     expect(createdResult.records).toHaveLength(1);
 
     // 4. Action: Retrieve using a non-matching filter
-    const docs = await ai.retrieve({
+    const docs = await setupCtx.ai.retrieve({
       retriever: RETRIEVER_REF,
       query: query,
       options: {

--- a/src/__tests__/neo4j2026.ts
+++ b/src/__tests__/neo4j2026.ts
@@ -1,0 +1,177 @@
+import { googleAI } from '@genkit-ai/googleai';
+import { Document, genkit } from 'genkit';
+import { test, describe, expect } from '@jest/globals';
+import {  neo4j, neo4jIndexerRef, neo4jRetrieverRef } from '..';
+import { mockEmbedder } from '../dummyEmbedder';
+import { setupNeo4jTestEnvironment } from '../test-utils';
+import { MatchSearchClauseStrategy } from '../search-strategy';
+
+
+/**
+ * This file contains integration tests for the Genkit Neo4j plugin using 
+ * using @testcontainers/neo4j with 2026.01.x and related features
+ */
+describe('Neo4j 2026.01+ Syntax Plugin Integration', () => {
+
+  // Initialize the before / after / beforeAll / afterAll
+  const setupCtx = setupNeo4jTestEnvironment();
+
+  test('should index and retrieve successfully without filterMetadata', async () => {
+    const customIdx = `match-strategy-no-filter-${Date.now()}`;
+    const uniqueId = `doc-${Date.now()}`;
+
+    // given
+    setupCtx.ai = genkit({
+      plugins: [
+        googleAI(),
+        neo4j([
+          {
+            indexId: customIdx,
+            embedder: mockEmbedder,
+            clientParams: setupCtx.clientParams,
+            searchStrategy: new MatchSearchClauseStrategy(),
+          },
+        ]),
+      ],
+    });
+
+    const newDocument = new Document({
+      content: [{ text: 'Document without filter metadata configuration.' }],
+      metadata: { uniqueId, color: 'red' },
+    });
+
+    const indexerRef = neo4jIndexerRef({ indexId: customIdx });
+    const retrieverRef = neo4jRetrieverRef({ indexId: customIdx });
+
+    // when
+    await setupCtx.ai.index({ indexer: indexerRef, documents: [newDocument] });
+
+    // then
+    const result = await setupCtx.session.run(
+      `MATCH (n:\`${customIdx}\` {uniqueId: $uniqueId}) RETURN n`,
+      { uniqueId }
+    );
+    expect(result.records).toHaveLength(1);
+    const props = result.records[0].get('n').properties;
+    expect(props.uniqueId).toBe(uniqueId);
+    expect(props.color).toBe('red');
+
+    const docs = await setupCtx.ai.retrieve({
+      retriever: retrieverRef,
+      query: 'test query',
+      options: { k: 10 },
+    });
+
+    expect(docs).toHaveLength(1);
+    expect(docs[0].content[0].text).toContain('without filter metadata configuration');
+  });
+
+  test('should index and retrieve successfully with explicitly empty filterMetadata', async () => {
+    const customIdx = `match-strategy-empty-filter-${Date.now()}`;
+    const uniqueId = `doc-${Date.now()}`;
+
+    // given
+    setupCtx.ai = genkit({
+      plugins: [
+        googleAI(),
+        neo4j([
+          {
+            indexId: customIdx,
+            embedder: mockEmbedder,
+            clientParams: setupCtx.clientParams,
+            searchStrategy: new MatchSearchClauseStrategy(),
+            filterMetadata: [],
+          },
+        ]),
+      ],
+    });
+
+    const newDocument = new Document({
+      content: [{ text: 'Document with empty filter metadata configuration.' }],
+      metadata: { uniqueId, shape: 'circle' },
+    });
+
+    const indexerRef = neo4jIndexerRef({ indexId: customIdx });
+    const retrieverRef = neo4jRetrieverRef({ indexId: customIdx });
+
+    // when
+    await setupCtx.ai.index({ indexer: indexerRef, documents: [newDocument] });
+
+    // then
+    const result = await setupCtx.session.run(
+      `MATCH (n:\`${customIdx}\` {uniqueId: $uniqueId}) RETURN n`,
+      { uniqueId }
+    );
+    expect(result.records).toHaveLength(1);
+
+    const docs = await setupCtx.ai.retrieve({
+      retriever: retrieverRef,
+      query: 'test query',
+      options: { k: 10 },
+    });
+
+    expect(docs).toHaveLength(1);
+    expect(docs[0].content[0].text).toContain('empty filter metadata configuration');
+  });
+
+  test('should index and retrieve successfully with populated filterMetadata and apply query filters', async () => {
+    const customIdx = `match-strategy-populated-filter-${Date.now()}`;
+
+    // given
+    setupCtx.ai = genkit({
+      plugins: [
+        googleAI(),
+        neo4j([
+          {
+            indexId: customIdx,
+            embedder: mockEmbedder,
+            clientParams: setupCtx.clientParams,
+            searchStrategy: new MatchSearchClauseStrategy(),
+            // Configure the index to optimize filtering on these specific metadata properties
+            filterMetadata: ['department', 'status'],
+          },
+        ]),
+      ],
+    });
+
+    const docsToInsert = [
+      new Document({
+        content: [{ text: 'Active document in IT.' }],
+        metadata: { department: 'IT', status: 'active', author: 'Alice' },
+      }),
+      new Document({
+        content: [{ text: 'Archived document in IT.' }],
+        metadata: { department: 'IT', status: 'archived', author: 'Bob' },
+      }),
+      new Document({
+        content: [{ text: 'Active document in HR.' }],
+        metadata: { department: 'HR', status: 'active', author: 'Charlie' },
+      }),
+    ];
+
+    const indexerRef = neo4jIndexerRef({ indexId: customIdx });
+    const retrieverRef = neo4jRetrieverRef({ indexId: customIdx });
+
+    // when
+    await setupCtx.ai.index({ indexer: indexerRef, documents: docsToInsert });
+
+    // then
+    const result = await setupCtx.session.run(`MATCH (n:\`${customIdx}\`) RETURN n`);
+    expect(result.records).toHaveLength(3);
+
+    const docs = await setupCtx.ai.retrieve({
+      retriever: retrieverRef,
+      query: 'Find active documents',
+      options: {
+        k: 10,
+        filter: { department: 'IT', status: 'active' }
+      },
+    });
+
+    // 4. Retrieval Verification: Should only return the single matching document
+    expect(docs).toHaveLength(1);
+    expect(docs[0].content[0].text).toBe('Active document in IT.');
+    expect(docs[0].metadata?.author).toBe('Alice');
+  });
+
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,16 +25,15 @@ import {
   indexerRef,
   retrieverRef,
 } from "genkit/retriever";
-import { constructMetadataFilter } from "./filter-utils";
 import { randomUUID } from 'crypto';
+import { SearchStrategy, VectorFunctionStrategy } from "./search-strategy";
 
-const FULLTEXT_INDEX_SUFFIX = "__fulltext";
+export const FULLTEXT_INDEX_SUFFIX = "__fulltext";
 export const errorMetadataAndHybrid =  "Metadata filtering can't be use in combination with a hybrid search approach."
 
 const Neo4jRetrieverOptionsSchema = CommonRetrieverOptionsSchema.extend({
   filter: z.record(z.string(), z.any()).optional(),
 });
-
 
 const Neo4jIndexerOptionsSchema = z.object({
   namespace: z.string().optional(),
@@ -47,14 +46,6 @@ export interface Neo4jGraphConfig {
   database?: string;
 }
 
-/**
- * neo4jRetrieverRef function creates a retriever for Neo4j.
- * @param params The params for the new Neo4j retriever
- * @param params.indexId The indexId for the Neo4j retriever
- * @param params.displayName  A display name for the retriever.
-If not specified, the default label will be `Neo4j - <indexId>`
- * @returns A reference to a Neo4j retriever.
- */
 export const neo4jRetrieverRef = (params: {
   indexId: string;
   displayName?: string;
@@ -85,11 +76,10 @@ export const neo4jIndexerRef = (params: {
     info: {
       label: params.displayName ?? `Neo4j - ${params.indexId}`,
     },
-    //configSchema: Neo4jIndexerOptionsSchema.optional(),
   });
 };
 
-interface Neo4jParams<EmbedderCustomOptions extends z.ZodTypeAny> {
+export interface Neo4jParams<EmbedderCustomOptions extends z.ZodTypeAny> {
   indexId: string;
   embedder: EmbedderArgument<EmbedderCustomOptions>;
   embedderOptions?: z.infer<EmbedderCustomOptions>;
@@ -98,11 +88,13 @@ interface Neo4jParams<EmbedderCustomOptions extends z.ZodTypeAny> {
   textProperty?: string;
   embeddingProperty?: string;
   idProperty?: string;
-  retrievalQuery?: string
+  retrievalQuery?: string;
   searchType?: SearchType;
   fullTextRetrievalQuery?: string;
   fullTextIndexName?: string;
   fullTextQuery?: string;
+  searchStrategy?: SearchStrategy;
+  filterMetadata?: string[];
 }
 
 /**
@@ -127,32 +119,22 @@ export function neo4j<EmbedderCustomOptions extends z.ZodTypeAny>(
 
 export default neo4j;
 
-/**
- * Configures a Neo4j retriever.
- * @param ai A Genkit instance
- * @param params The params for the retriever
- * @param params.indexId The name of the retriever
- * @param params.clientParams PNeo4jConfiguration containing the
-username, password, and url. If not set, the NEO4J_URI, NEO4J_USERNAME,
-and NEO4J_PASSWORD environment variable will be used instead.
- * @param params.embedder The embedder to use for the retriever
- * @param params.embedderOptions  Options to customize the embedder
- * @returns A Pinecone retriever
- */
 export function configureNeo4jRetriever<
   EmbedderCustomOptions extends z.ZodTypeAny,
 >(
   ai: Genkit,
   params: Neo4jParams<EmbedderCustomOptions>,
 ) {
-  const { indexId, embedder, embedderOptions } = {
-    ...params,
-  };
+  const { indexId, embedder, embedderOptions, searchStrategy } = { ...params };
   const neo4jConfig = params.clientParams ?? getDefaultConfig();
   const neo4j_instance = neo4j_driver.driver(
     neo4jConfig.url, // URL (protocol://host:port)
     neo4j_driver.auth.basic(neo4jConfig.username, neo4jConfig.password), // Authentication
   );
+  
+  // Default to VectorFunctionStrategy
+  const strategy = searchStrategy || new VectorFunctionStrategy();
+
   return ai.defineRetriever(
     {
       name: `neo4j/${params.indexId}`,
@@ -165,7 +147,9 @@ export function configureNeo4jRetriever<
         options: embedderOptions,
       });
 
-      const retriever_query = retrieverQuery(options, params, content?.text ?? '');
+      // Delegate query generation to the strategy
+      const retriever_query = strategy.generateQuery(options, params, content?.text ?? '');
+      
       const response = await neo4j_instance.executeQuery(
         retriever_query.query,
         {
@@ -178,7 +162,7 @@ export function configureNeo4jRetriever<
           database: neo4jConfig.database,
         },
       );
-      // Create documents properly by returning the result from map
+      
       const documents = response.records.map((el) => {
         return Document.fromText(
           el.get("text"),
@@ -195,107 +179,14 @@ export function configureNeo4jRetriever<
   );
 }
 
-const retrieverQuery = <EmbedderCustomOptions extends z.ZodTypeAny>(
-  options: {
-    filter?: Record<string, any> | undefined;
-    k?: number | undefined;
-  },
-  params: Neo4jParams<EmbedderCustomOptions>,
-  content: string,
-): {query: string, additionalParams: Record<string, any>} => {
-  const filter = options.filter;
-  const { indexId, label, embeddingProperty = 'embedding', textProperty = 'text', fullTextIndexName = params.indexId + FULLTEXT_INDEX_SUFFIX } = params;
-
-  const nodeLabel = label || indexId;
-  
-  const retrievalQuery = params?.retrievalQuery ?? `RETURN node.${textProperty} AS text, node {.*, text: Null,
-      embedding: Null, id: Null } AS metadata`;
-
-  const fullTextRetrievalQuery = params?.fullTextRetrievalQuery ?? retrievalQuery;
-  const isHybrid = params?.searchType === 'hybrid';
-  if (params?.fullTextQuery == undefined && content == undefined) {
-    throw new Error("Neither fullTextQuery nor content is defined for hybrid search.");
-  }
-
-  if (filter == null) {
-      const hybridQuery =`
-          CALL {
-              CALL db.index.vector.queryNodes($index, $k * 5, $embedding) YIELD node, score
-              WITH collect({node:node, score:score}) AS nodes, max(score) AS max
-              UNWIND nodes AS n
-              // We use 0 as min
-              RETURN n.node AS node, (n.score / max) AS score 
-              UNION
-              CALL db.index.fulltext.queryNodes("${fullTextIndexName}", $fullTextQuery, {limit: $k}) YIELD node, score
-              WITH collect({node: node, score: score}) AS nodes, max(score) AS max
-              UNWIND nodes AS n
-              RETURN n.node AS node, (n.score / max) AS score
-          }
-          WITH node, max(score) AS score ORDER BY score DESC LIMIT toInteger($k)
-          ${fullTextRetrievalQuery}`
-
-    const vectorQuery = `
-      CALL db.index.vector.queryNodes($index, $k, $embedding) YIELD node, score
-      ${retrievalQuery}
-      `;
-      
-    const query = isHybrid
-      ? hybridQuery
-      : vectorQuery;
-
-    isHybrid && console.log("Generated Query name:", fullTextIndexName);
-      
-    const additionalParams = isHybrid
-      ? {fullTextQuery: params?.fullTextQuery ?? content, fullTextIndexName: fullTextIndexName}
-      : {};
-
-    return { query, additionalParams };
-  }
-
-  if (isHybrid) {
-    throw new Error(errorMetadataAndHybrid);
-  }
-  
-  const baseIndexQuery = `
-    CYPHER runtime = parallel parallelRuntimeSupport=all 
-    MATCH (n:\`${nodeLabel}\`)
-    WHERE n.\`${embeddingProperty}\` IS NOT NULL
-    AND
-  `;
-
-  const baseCosineQuery = `
-    WITH n as node, vector.similarity.cosine(
-      n.\`${embeddingProperty}\`,
-      $embedding
-    ) AS score ORDER BY score DESC LIMIT toInteger($k)
-  `;
-  const [fSnippets, fParams] = constructMetadataFilter(filter);
-
-  const indexQuery = baseIndexQuery + fSnippets + baseCosineQuery + retrievalQuery;
-
-  return {query: indexQuery, additionalParams: fParams};
-}
-
-
-/**
- * Configures a Neo4j indexer.
- * @param ai A Genkit instance
- * @param params The params for the indexer
- * @param params.indexId The name of the indexer
- * @param params.clientParams Neo4jConfiguration containing the
-username, password, and url. If not set, the NEO4J_URI, NEO4J_USERNAME,
-and NEO4J_PASSWORD environment variable will be used instead.
- * @param params.embedder The embedder to use for the retriever
- * @param params.embedderOptions  Options to customize the embedder
- * @returns A Genkit indexer
- */
 export function configureNeo4jIndexer<
   EmbedderCustomOptions extends z.ZodTypeAny,
 >(
   ai: Genkit,
   params: Neo4jParams<EmbedderCustomOptions>
 ) {
-  const { indexId, 
+  const { 
+    indexId, 
     embedder, 
     embedderOptions,
     embeddingProperty = 'embedding',
@@ -305,19 +196,23 @@ export function configureNeo4jIndexer<
     searchType = 'vector',
     fullTextIndexName = indexId + FULLTEXT_INDEX_SUFFIX,
     fullTextQuery,
+    searchStrategy,
+    filterMetadata = []
   } = {
     ...params,
   };
   const neo4jConfig = params.clientParams ?? getDefaultConfig();
   const neo4j_instance = neo4j_driver.driver(
-    neo4jConfig.url, // URL (protocol://host:port)
-    neo4j_driver.auth.basic(neo4jConfig.username, neo4jConfig.password), // Authentication
+    neo4jConfig.url, 
+    neo4j_driver.auth.basic(neo4jConfig.username, neo4jConfig.password), 
   );
+
+  const strategy = searchStrategy || new VectorFunctionStrategy();
+  const cypherPrefix = strategy.cypherPrefix();
 
   return ai.defineIndexer(
     {
       name: `neo4j/${params.indexId}`,
-      //configSchema: neo4jIndexerOptionsSchema.optional(),
     },
     async (docs, options) => {
       const embeddings = await Promise.all(
@@ -362,11 +257,20 @@ export function configureNeo4jIndexer<
         );
       }
 
+      let withMetadataClause = "";
+      if (filterMetadata.length > 0) {
+        // Mappa le chiavi nell'array in formato n.`chiave` e le unisce con la virgola
+        const metadataProps = filterMetadata.map(key => `n.\`${key}\``).join(", ");
+        withMetadataClause = ` WITH [${metadataProps}]`;
+      }
+
+      const createVectorIndexQuery = `
+      ${cypherPrefix}CREATE VECTOR INDEX $indexName IF NOT EXISTS
+      FOR (n:\`${labelName}\`) ON (n.\`${embeddingProperty}\`)${withMetadataClause}
+            `.trim();
+
       await neo4j_instance.executeQuery(
-        `
-        CREATE VECTOR INDEX $indexName IF NOT EXISTS
-        FOR (n:\`${labelName}\`) ON n.embedding
-        `,
+        createVectorIndexQuery,
         { indexName: indexId },
         { database: neo4jConfig.database },
       );
@@ -414,5 +318,5 @@ function getDefaultConfig() {
   };
 }
 
-type SearchType = "vector" | "hybrid"
+type SearchType = "vector" | "hybrid";
 

--- a/src/search-strategy.ts
+++ b/src/search-strategy.ts
@@ -1,0 +1,136 @@
+import { errorMetadataAndHybrid, FULLTEXT_INDEX_SUFFIX, Neo4jParams } from ".";
+import { z } from "genkit";
+import { constructMetadataFilter } from "./filter-utils";
+
+export interface SearchStrategy {
+  cypherPrefix(): string;
+  generateQuery<T extends z.ZodTypeAny>(
+    options: { filter?: Record<string, any>; k?: number },
+    params: Neo4jParams<T>,
+    content: string
+  ): { query: string; additionalParams: Record<string, any> };
+}
+
+export class VectorFunctionStrategy implements SearchStrategy {
+  cypherPrefix() { return "" }
+
+  generateQuery<EmbedderCustomOptions extends z.ZodTypeAny>(
+    options: { filter?: Record<string, any>; k?: number },
+    params: Neo4jParams<EmbedderCustomOptions>,
+    content: string
+  ): { query: string; additionalParams: Record<string, any> } {
+    const filter = options.filter;
+    const { 
+      indexId, 
+      label, 
+      embeddingProperty = 'embedding', 
+      textProperty = 'text', 
+      fullTextIndexName = params.indexId + FULLTEXT_INDEX_SUFFIX
+    } = params;
+
+    const nodeLabel = label || indexId;
+    
+    const retrievalQuery = params?.retrievalQuery ?? `RETURN node.${textProperty} AS text, node {.*, text: Null, embedding: Null, id: Null } AS metadata`;
+    const fullTextRetrievalQuery = params?.fullTextRetrievalQuery ?? retrievalQuery;
+    const isHybrid = params?.searchType === 'hybrid';
+
+    if (params?.fullTextQuery == undefined && content == undefined && isHybrid) {
+      throw new Error("Neither fullTextQuery nor content is defined for hybrid search.");
+    }
+
+    if (filter == null) {
+      const hybridQuery = `
+          CALL {
+              CALL db.index.vector.queryNodes($index, $k * 5, $embedding) YIELD node, score
+              WITH collect({node:node, score:score}) AS nodes, max(score) AS max
+              UNWIND nodes AS n
+              // We use 0 as min
+              RETURN n.node AS node, (n.score / max) AS score 
+              UNION
+              CALL db.index.fulltext.queryNodes("${fullTextIndexName}", $fullTextQuery, {limit: $k}) YIELD node, score
+              WITH collect({node: node, score: score}) AS nodes, max(score) AS max
+              UNWIND nodes AS n
+              RETURN n.node AS node, (n.score / max) AS score
+          }
+          WITH node, max(score) AS score ORDER BY score DESC LIMIT toInteger($k)
+          ${fullTextRetrievalQuery}`;
+
+      const vectorQuery = `
+        CALL db.index.vector.queryNodes($index, $k, $embedding) YIELD node, score
+        ${retrievalQuery}
+      `;
+        
+      const query = isHybrid ? hybridQuery : vectorQuery;
+
+      isHybrid && console.log("Generated Query name:", fullTextIndexName);
+        
+      const additionalParams = isHybrid
+        ? { fullTextQuery: params?.fullTextQuery ?? content, fullTextIndexName: fullTextIndexName }
+        : {};
+
+      return { query, additionalParams };
+    }
+
+    if (isHybrid) {
+      throw new Error(errorMetadataAndHybrid);
+    }
+    
+    const baseIndexQuery = `
+      CYPHER runtime = parallel parallelRuntimeSupport=all 
+      MATCH (n:\`${nodeLabel}\`)
+      WHERE n.\`${embeddingProperty}\` IS NOT NULL
+      AND
+    `;
+
+    const baseCosineQuery = `
+      WITH n as node, vector.similarity.cosine(
+        n.\`${embeddingProperty}\`,
+        $embedding
+      ) AS score ORDER BY score DESC LIMIT toInteger($k)
+    `;
+    const [fSnippets, fParams] = constructMetadataFilter(filter);
+
+    const indexQuery = baseIndexQuery + fSnippets + baseCosineQuery + retrievalQuery;
+
+    return { query: indexQuery, additionalParams: fParams };
+  }
+}
+
+export class MatchSearchClauseStrategy implements SearchStrategy {
+  cypherPrefix() { return "CYPHER 25" };
+
+  generateQuery<EmbedderCustomOptions extends z.ZodTypeAny>(
+    options: { filter?: Record<string, any>; k?: number },
+    params: Neo4jParams<EmbedderCustomOptions>,
+    content: string
+  ): { query: string; additionalParams: Record<string, any> } {
+    const { filter, k } = options;
+    const { indexId, textProperty = 'text' } = params;
+    
+    const retrievalQuery = params?.retrievalQuery ?? `RETURN node.${textProperty} AS text, node {.*, text: Null, embedding: Null, id: Null } AS metadata`;
+    
+    let filterClause = "";
+    let additionalParams: Record<string, any> = {};
+
+    if (filter) {
+      const [fSnippets, fParams] = constructMetadataFilter(filter);
+      // Map 'n.' references from constructMetadataFilter to 'node.' for the SEARCH clause
+      filterClause = `WHERE ${fSnippets.replace(/n\./g, 'node.')}`;
+      additionalParams = fParams;
+    }
+
+    const query = `
+      CYPHER 25
+      MATCH (node)
+      SEARCH node IN (
+          VECTOR INDEX \`${indexId}\`
+          FOR $embedding
+          ${filterClause}
+          LIMIT toInteger($k)
+      ) SCORE AS score
+      ${retrievalQuery}
+    `.trim();
+
+    return { query, additionalParams };
+  }
+}

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -1,0 +1,73 @@
+import { beforeAll, beforeEach, afterEach, afterAll } from '@jest/globals';
+import { Neo4jContainer, StartedNeo4jContainer } from '@testcontainers/neo4j';
+import { Wait } from 'testcontainers';
+import { driver as neo4jDriver, auth, Driver, Session } from 'neo4j-driver';
+import { genkit } from 'genkit';
+import { googleAI } from '@genkit-ai/googleai';
+import { neo4j } from '.';
+import { mockEmbedder } from './dummyEmbedder';
+
+export interface Neo4jTestStartupContext {
+  neo4jContainer: StartedNeo4jContainer;
+  driver: Driver;
+  session: Session;
+  ai: ReturnType<typeof genkit>;
+  clientParams: any;
+}
+
+export function setupNeo4jTestEnvironment(neo4jVersion: string = '2026.01.4', indexId: string = 'genkit-test-index'): Neo4jTestStartupContext {
+  // We an empty object that will be populated by the hooks.
+  const setupCtx = {} as Neo4jTestStartupContext;
+  const CLEANUP_QUERY = `MATCH (n) DETACH DELETE n`;
+
+  beforeAll(async () => {
+    setupCtx.neo4jContainer = await new Neo4jContainer(`neo4j:${neo4jVersion}`)
+      .withWaitStrategy(Wait.forLogMessage('Started.'))
+      .start();
+
+    const uri = setupCtx.neo4jContainer.getBoltUri();
+    const username = setupCtx.neo4jContainer.getUsername();
+    const password = setupCtx.neo4jContainer.getPassword();
+
+    setupCtx.driver = neo4jDriver(uri, auth.basic(username, password));
+  }, 120000);
+
+  beforeEach(async () => {
+    setupCtx.clientParams = {
+      url: setupCtx.neo4jContainer.getBoltUri(),
+      username: setupCtx.neo4jContainer.getUsername(),
+      password: setupCtx.neo4jContainer.getPassword(),
+      database: 'neo4j',
+    };
+
+    setupCtx.ai = genkit({
+      plugins: [
+        googleAI(),
+        neo4j([
+          {
+            indexId,
+            embedder: mockEmbedder,
+            clientParams: setupCtx.clientParams,
+          },
+        ]),
+      ],
+    });
+
+    setupCtx.session = setupCtx.driver.session();
+  });
+
+  afterEach(async () => {
+    try {
+      await setupCtx.session.run(CLEANUP_QUERY);
+    } finally {
+      await setupCtx.session.close();
+    }
+  });
+
+  afterAll(async () => {
+    await setupCtx.driver.close();
+    await setupCtx.neo4jContainer.stop();
+  });
+
+  return setupCtx;
+}


### PR DESCRIPTION
Update indexer and retriever to support the new Vector Search syntax introduced in Neo4j version 2026.01 (Preview), enabling native in-index filtering, see [here](https://medium.com/neo4j/vector-search-with-filters-in-neo4j-v2026-01-preview-1559829b099d).

- Using strategy pattern, to be consistent to langchain4j implementation: https://github.com/langchain4j/langchain4j-community/pull/565, using an interface with `cypherPrefix` (to add "CYPHER 25" with 2026.01 syntax) and `generateQuery` (to retrieve using the pre-filtering syntax or the current one)
- created `test-utils.ts` to commonize before/after/beforeAll/afterAll and created `neo4j2026.ts` test, which leverages Neo4j 2026.01+ and the new feature
